### PR TITLE
Fix "Staff Roles" errata

### DIFF
--- a/tickets/setupTickets.cc.lua
+++ b/tickets/setupTickets.cc.lua
@@ -13,7 +13,7 @@
 
 {{/* USER VARIABLES */}}
 
-    {{/* Satff Roles */}}
+    {{/* Staff Roles */}}
         {{$Admins := cslice 673258482211749917}} {{/* IDs of your ADMINs Roles. Leave the "cslice" here even if you have only 1 role */}}
         {{$Mods := cslice 674429313097007106}} {{/* IDs of your MODs Roles. Leave the "cslice" here even if you have only 1 role */}}
         {{$MentionRoleID := 647298324734541827}} {{/* Role to be mentioned when a new ticket is opened */}}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Ticket system -> Setup CC -> There was an errata, on `Staff Roles` section of configuration variables (the comment itself)

**Status**

- [ ] Code changes have been tested on an instance of YAGPDB, **or there are no code changes**
- [x] I have read and followed the [contribution guide](../CONTRIBUTING.md)
